### PR TITLE
feat (editor, dirops): Filename as an argument when running editor

### DIFF
--- a/src/dirops.py
+++ b/src/dirops.py
@@ -165,6 +165,20 @@ def change_default_path(original_destination):
         print(f"Error changing path: {e}")
         return 1
 
+
+def ensure_directory_exists(filepath):
+    """Create parent directories if they don't exist"""
+    directory = os.path.dirname(filepath)
+    if directory and not os.path.exists(directory):
+        try:
+            os.makedirs(directory)
+            print(f"Created directory: {directory}")
+            return True
+        except OSError as e:
+            print(f"Error creating directory: {e}")
+            return False
+    return True  # Directory already exists
+
 def count_words_in_file(filename):
     """
     Count the number of words in a text file with improved punctuation handling.

--- a/src/editor.py
+++ b/src/editor.py
@@ -18,6 +18,12 @@ import execmode
 import utils
 from text_buffer import TextBuffer
 
+def parse_arguments():
+    """Handle command-line arguments"""
+    import argparse
+    parser = argparse.ArgumentParser(description='PyLine Text Editor')
+    parser.add_argument('filename', nargs='?', help='File to edit')
+    return parser.parse_args()
 
 def main():
     # Register signal handler (for OS-level interrupts)
@@ -29,11 +35,33 @@ def main():
     original_destination = dirops.original_destination()
     dirops.default_path(original_destination)
     current_dir = dirops.currentdir()
-    
+
     print('PyLine 0.6 - (GPLv3) for Linux/BSD  Copyright (C) 2018-2025  Peter Leukanič')
     print('This program comes with ABSOLUTELY NO WARRANTY; for details type \'i\'.\n')
     
+    args = parse_arguments()
+    buffer = TextBuffer()
+    
     try:
+        if args.filename:  # File specified via command line
+            filepath = os.path.abspath(args.filename)
+            
+            if os.path.exists(filepath):
+                if buffer.load_file(filepath):
+                    buffer.edit_interactive()
+                else:
+                    print(f"Error: Could not load {filepath}")
+            else:
+                # Create directory structure if needed
+                if dirops.ensure_directory_exists(filepath):
+                    print(f"Creating new file: {filepath}")
+                    buffer.filename = filepath
+                    buffer.edit_interactive()
+                else:
+                    print("Failed to create directory structure")
+            utils.clean_exit()
+            return
+        
         choice = None
         while choice != 'q':
             buffer = TextBuffer()


### PR DESCRIPTION
- PyLine now supports filename as an argument and will directly open a file for editing.
- If file doesen't exist, it will be created. Dierctory in it's path will be created too, if it alredy does't exists.