### PR TITLE
fix(text_buffer.py): Atmoic paste/delete + docs(README): formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ To unninstall the program:
 **Advanced Hook System**
 
 More about hooks in: [hooks-creation](https://github.com/Peter-L-SVK/PyLine/blob/main/hooks/hooks-creation.md) and [hooks-overview](https://github.com/Peter-L-SVK/PyLine/blob/main/hooks/hooks-overview.md)  
+Manual on how to perform various types of search and replace within core hook in [serach-replace manual](https://github.com/Peter-L-SVK/PyLine/blob/main/hooks/search_replace/readme.md)  
 PyLine features a comprehensive hook system that allows extending functionality through plugins. The hook system supports multiple programming languages and follows a structured directory hierarchy:
 
 ```


### PR DESCRIPTION
- Brings back atomic multiline paste/delete
- Fixing how multilines are performed
- Instead of line by line, it's now one operation
- Including search and replace hook's manual